### PR TITLE
Update environment-lab.yml

### DIFF
--- a/environment-lab.yml
+++ b/environment-lab.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
 dependencies:
   - jupyterlab =3
-  - jupyter_bokeh
+  - pyviz_comms
 platforms:
   - osx-arm64


### PR DESCRIPTION
`jupyter_bokeh` is not needed but `pyviz_comms` is. Panel usually pulls this in automatically but if you install panel in a separate kernel environment you have to explicitly add it to the JupyterLab env.